### PR TITLE
Add a helpful GitHub Pages catalog page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python tools/build_catalog.py
 
+      - name: Stage website
+        run: |
+          cp site/index.html dist/index.html
+          cp site/developers.html dist/developers.html
+          cp site/style.css dist/style.css
+          cp site/script.js dist/script.js
+
       - name: Stage icons alongside the catalog
         # icons_vita/ publishes to dist/icons/ (unchanged path, kept exactly
         # where already-published clients expect vita icons); icons_psp/ gets

--- a/README.md
+++ b/README.md
@@ -194,3 +194,14 @@ GITHUB_TOKEN=$(gh auth token) python tools/build_catalog.py
 
 Without a token you share the anonymous API budget of 60 calls an hour, which runs
 out quickly once the catalog grows.
+
+### Website deployment
+
+The browser catalog source lives under `site/`. The `Build catalog` workflow copies
+those HTML, CSS and JavaScript files into `dist/`, stages the repository icons, and
+deploys the complete result to GitHub Pages. The website continues to read the
+public Vita and PSP JSON feeds at runtime; those feeds are not copied into `site/`.
+
+For a fork, enable GitHub Pages with **Source: GitHub Actions** under Settings →
+Pages. Pushes to `main`, scheduled builds, and manual workflow runs publish the
+site automatically.

--- a/site/developers.html
+++ b/site/developers.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NeoVitaDB — Developers</title>
+  <meta name="description" content="Learn how to add a PS Vita or PSP homebrew project to the NeoVitaDB catalog." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="wavefield" aria-hidden="true">
+    <div class="wave wave-a"></div>
+    <div class="wave wave-b"></div>
+    <div class="wave wave-c"></div>
+  </div>
+
+  <header class="xmb-bar" data-testid="developers-header">
+    <a class="xmb-brand brand-link" href="index.html" aria-label="Back to NeoVitaDB catalog">
+      <svg viewBox="0 0 64 64" class="brand-glyph" aria-hidden="true">
+        <path class="g-triangle" d="M32 10 L50 42 L14 42 Z" />
+        <circle class="g-circle" cx="46" cy="46" r="9" />
+        <path class="g-cross" d="M12 38 L28 54 M28 38 L12 54" stroke-width="4" stroke-linecap="round" />
+        <rect class="g-square" x="4" y="6" width="16" height="16" rx="2" />
+      </svg>
+      <div class="brand-text">
+        <h1>NeoVita<span>DB</span></h1>
+        <p class="tagline">developer guide</p>
+      </div>
+    </a>
+    <a class="developer-link" href="index.html" data-testid="catalog-link">&lt; Back to catalog</a>
+  </header>
+
+  <main class="developer-page" aria-labelledby="developer-guide-title">
+    <section class="developer-hero">
+      <div class="guide-mark" aria-hidden="true">&lt;/&gt;</div>
+      <div>
+        <p class="eyebrow">For developers</p>
+        <h2 id="developer-guide-title">Add your homebrew to NeoVitaDB</h2>
+        <p>Share your PS Vita or PSP project with the community. The catalog stores your project details and CI resolves release information automatically.</p>
+      </div>
+    </section>
+
+    <section class="developer-content">
+      <div class="developer-column">
+        <div class="developer-step">
+          <span class="step-number">01</span>
+          <div><h3>Create an entry</h3><p>Copy the platform template and save it under <code>apps/vita/</code> or <code>apps/psp/</code> using the next available id.</p></div>
+        </div>
+        <div class="developer-step">
+          <span class="step-number">02</span>
+          <div><h3>Add your icon</h3><p>Place a matching 128x128 PNG in <code>icons_vita/</code> or <code>icons_psp/</code>. Use the same filename as the entry slug.</p></div>
+        </div>
+        <div class="developer-step">
+          <span class="step-number">03</span>
+          <div><h3>Open a pull request</h3><p>Describe the project, link its GitHub repository, and let CI validate the metadata before it is published.</p></div>
+        </div>
+        <a class="guide-cta" href="https://github.com/robin994/NeoVitaDB-Catalog#adding-your-homebrew" target="_blank" rel="noopener">Read the full contribution guide <span aria-hidden="true">-&gt;</span></a>
+      </div>
+
+      <div class="developer-column">
+        <div class="developer-panel">
+          <p class="eyebrow">Entry example</p>
+          <pre class="guide-code" aria-label="Example homebrew entry"><code>{
+  <span>"id"</span>: <strong>42</strong>,
+  <span>"name"</span>: <em>"My Homebrew"</em>,
+  <span>"author"</span>: <em>"Your Name"</em>,
+  <span>"category"</span>: <em>"game"</em>,
+  <span>"platform"</span>: <em>"vita"</em>,
+  <span>"titleid"</span>: <em>"MYHB00001"</em>,
+  <span>"repo"</span>: <em>"youruser/your-repo"</em>,
+  <span>"asset"</span>: <em>"*.vpk"</em>,
+  <span>"icon"</span>: <em>"0042-my-homebrew.png"</em>,
+  <span>"description"</span>: <em>"What it does."</em>
+}</code></pre>
+        </div>
+        <div class="developer-note"><strong>Keep in mind</strong><p>Version, release date, size, download count, checksums, and download URL are filled from your latest GitHub release. The <code>trusted</code> flag is recalculated from repository stars.</p></div>
+      </div>
+    </section>
+
+    <section class="developer-reference" aria-labelledby="catalog-reference-title">
+      <div class="reference-heading">
+        <p class="eyebrow">For catalog users</p>
+        <h2 id="catalog-reference-title">How this repository works</h2>
+        <p>This is a static catalog. Consume the generated feeds and hosted assets from GitHub Pages; use the repository files when you need contributor metadata or want to build your own catalog.</p>
+      </div>
+
+      <div class="reference-grid">
+        <article class="reference-item">
+          <h3>Generated catalog feeds</h3>
+          <p>These are the recommended endpoints for an app or website. Each item contains its resolved version, release data, download URL, checksums, and metadata.</p>
+          <code class="url-example">https://robin994.github.io/NeoVitaDB-Catalog/vita.json</code>
+          <code class="url-example">https://robin994.github.io/NeoVitaDB-Catalog/psp.json</code>
+        </article>
+
+        <article class="reference-item">
+          <h3>Hosted icons</h3>
+          <p>Use the <code>icon</code> filename from a feed item. Vita icons are published at <code>/icons/</code>; PSP icons are published at <code>/icons_psp/</code>.</p>
+          <code class="url-example">https://robin994.github.io/NeoVitaDB-Catalog/icons/0001-neovitadb-downloader.png</code>
+          <code class="url-example">https://robin994.github.io/NeoVitaDB-Catalog/icons_psp/0001-example.png</code>
+        </article>
+
+        <article class="reference-item">
+          <h3>Repository source files</h3>
+          <p>Contributor entries and original icons are kept in the repository. These paths are useful for inspection, but generated feeds are more stable for catalog clients.</p>
+          <code class="url-example">https://raw.githubusercontent.com/robin994/NeoVitaDB-Catalog/main/apps/vita/0001-neovitadb-downloader.json</code>
+          <code class="url-example">https://raw.githubusercontent.com/robin994/NeoVitaDB-Catalog/main/icons_vita/0001-neovitadb-downloader.png</code>
+        </article>
+
+        <article class="reference-item">
+          <h3>Using a fork</h3>
+          <p>Replace the owner and repository name in every hosted URL after enabling GitHub Pages with the GitHub Actions source on your fork.</p>
+          <code class="url-example">https://your-user.github.io/your-catalog/vita.json</code>
+          <code class="url-example">https://your-user.github.io/your-catalog/icons/your-icon.png</code>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>NeoVitaDB Catalog · <a href="index.html">Browse homebrew</a></p>
+  </footer>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NeoVitaDB — PS Vita &amp; PSP Homebrew Catalog</title>
+  <meta name="description" content="Browse the NeoVitaDB homebrew catalog for PlayStation Vita and PSP. Search games, ports, utilities and emulators." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+  <!-- Power-on sequence, styled after the PSP/Vita boot flash. Skips itself if the
+       visitor prefers reduced motion, and can be dismissed with any key or click. -->
+  <div class="boot" id="boot" data-testid="boot-sequence" aria-hidden="true">
+    <div class="boot-sweep"></div>
+    <div class="boot-mark">
+      <svg viewBox="0 0 64 64" class="boot-glyph" aria-hidden="true">
+        <path class="g-triangle" d="M32 10 L50 42 L14 42 Z" />
+        <circle class="g-circle" cx="46" cy="46" r="9" />
+        <path class="g-cross" d="M12 38 L28 54 M28 38 L12 54" stroke-width="4" stroke-linecap="round" />
+        <rect class="g-square" x="4" y="6" width="16" height="16" rx="2" />
+      </svg>
+      <p class="boot-label">NEOVITADB</p>
+    </div>
+    <p class="boot-skip">press any key</p>
+  </div>
+
+  <!-- Ambient XMB-style wave field, sits behind everything -->
+  <div class="wavefield" aria-hidden="true">
+    <div class="wave wave-a"></div>
+    <div class="wave wave-b"></div>
+    <div class="wave wave-c"></div>
+  </div>
+
+  <header class="xmb-bar" data-testid="site-header">
+    <div class="xmb-brand">
+      <svg viewBox="0 0 64 64" class="brand-glyph" aria-hidden="true">
+        <path class="g-triangle" d="M32 10 L50 42 L14 42 Z" />
+        <circle class="g-circle" cx="46" cy="46" r="9" />
+        <path class="g-cross" d="M12 38 L28 54 M28 38 L12 54" stroke-width="4" stroke-linecap="round" />
+        <rect class="g-square" x="4" y="6" width="16" height="16" rx="2" />
+      </svg>
+      <div class="brand-text">
+        <h1 data-testid="site-title">NeoVita<span>DB</span></h1>
+        <p class="tagline">homebrew &amp; ports · vita / psp</p>
+      </div>
+    </div>
+
+    <nav class="xmb-tabs" role="tablist" aria-label="Platform" data-testid="platform-tabs">
+      <button class="xmb-tab active" data-platform="all" data-testid="platform-all" role="tab" aria-selected="true">
+        <span class="tab-icon tab-icon-all" aria-hidden="true"></span>
+        <span class="tab-label">All</span>
+      </button>
+      <button class="xmb-tab" data-platform="vita" data-testid="platform-vita" role="tab" aria-selected="false">
+        <span class="tab-icon tab-icon-vita" aria-hidden="true"></span>
+        <span class="tab-label">Vita</span>
+      </button>
+      <button class="xmb-tab" data-platform="psp" data-testid="platform-psp" role="tab" aria-selected="false">
+        <span class="tab-icon tab-icon-psp" aria-hidden="true"></span>
+        <span class="tab-label">PSP</span>
+      </button>
+    </nav>
+
+    <div class="xmb-info" data-testid="header-stats">
+      <div class="info-clock" id="clock" data-testid="clock"></div>
+      <div class="info-stats">
+        <div class="stat"><span class="stat-num" id="stat-total" data-testid="stat-total">—</span><span class="stat-label">entries</span></div>
+        <div class="stat"><span class="stat-num" id="stat-vita" data-testid="stat-vita">—</span><span class="stat-label">vita</span></div>
+        <div class="stat"><span class="stat-num" id="stat-psp" data-testid="stat-psp">—</span><span class="stat-label">psp</span></div>
+      </div>
+      <a class="developer-link" href="developers.html" data-testid="developers-link"><span aria-hidden="true">&lt;/&gt;</span> Developers</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="controls" data-testid="controls">
+      <div class="search-wrap">
+        <svg class="search-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="M20 20L17 17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        <input id="search" type="text" placeholder="Search by name or author…" data-testid="search-input" autocomplete="off" />
+      </div>
+
+      <select id="category" class="native-select" data-testid="category-select" aria-label="Category">
+        <option value="all">All categories</option>
+        <option value="Original Game">▲ Original Game</option>
+        <option value="Game Port">■ Game Port</option>
+        <option value="Utility">✕ Utility</option>
+        <option value="Emulator">● Emulator</option>
+      </select>
+
+      <select id="sort" class="native-select" data-testid="sort-select" aria-label="Sort">
+        <option value="downloads">Most downloaded</option>
+        <option value="date">Newest</option>
+        <option value="name">Name (A–Z)</option>
+      </select>
+
+      <div class="filter-options" aria-label="Catalog options">
+        <label class="filter-option">
+          <input id="trusted-only" type="checkbox" data-testid="trusted-filter" />
+          <span>Trusted only</span>
+        </label>
+        <label class="filter-option">
+          <input id="include-ai" type="checkbox" data-testid="ai-filter" checked />
+          <span>Include AI-assisted</span>
+        </label>
+      </div>
+    </section>
+
+    <div class="result-bar">
+      <span id="result-count" class="result-count" data-testid="result-count"></span>
+      <button id="reset" class="reset-btn" data-testid="reset-btn" hidden>Clear filters</button>
+    </div>
+
+    <section id="grid" class="grid" data-testid="grid" aria-live="polite"></section>
+
+    <div id="loading" class="state" data-testid="loading-state">
+      <div class="disc-spinner" aria-hidden="true"><span></span></div>
+      <p>Reading disc…</p>
+    </div>
+
+    <div id="error" class="state" data-testid="error-state" hidden>
+      <p class="state-title">Couldn't load the catalog</p>
+      <p id="error-msg" class="state-sub"></p>
+      <button id="retry" class="reset-btn" data-testid="retry-btn">Try again</button>
+    </div>
+
+    <div id="empty" class="state" data-testid="empty-state" hidden>
+      <p class="state-title">No results</p>
+      <p class="state-sub">Try a different search or clear the filters.</p>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <p>Data from <a href="https://robin994.github.io/NeoVitaDB-Catalog/" target="_blank" rel="noopener">NeoVitaDB Catalog</a> · unofficial browser for the public JSON feed</p>
+  </footer>
+
+  <div id="modal" class="modal" data-testid="detail-modal" hidden>
+    <div class="modal-backdrop" data-testid="modal-backdrop"></div>
+    <div class="modal-card" role="dialog" aria-modal="true">
+      <button class="modal-close" id="modal-close" data-testid="modal-close" aria-label="Close">&times;</button>
+      <div id="modal-body" class="modal-body"></div>
+      <div class="modal-prompts" id="modal-prompts"></div>
+    </div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/site/script.js
+++ b/site/script.js
@@ -1,0 +1,288 @@
+"use strict";
+
+const FEEDS = {
+  vita: "https://robin994.github.io/NeoVitaDB-Catalog/vita.json",
+  psp: "https://robin994.github.io/NeoVitaDB-Catalog/psp.json",
+};
+const CAT_MAP = { 1: "Original Game", 2: "Game Port", 4: "Utility", 5: "Emulator" };
+
+// Each category is tied to a real PlayStation face button — used as a small
+// glyph + accent color instead of an arbitrary color swatch.
+const CAT_GLYPH = {
+  "Original Game": { shape: "triangle", color: "var(--triangle)" },
+  "Game Port": { shape: "square", color: "var(--square)" },
+  "Utility": { shape: "cross", color: "var(--cross)" },
+  "Emulator": { shape: "circle", color: "var(--circle)" },
+};
+
+const FILTER_STORAGE_KEY = "neovita-filter-preferences";
+const savedFilters = (() => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(FILTER_STORAGE_KEY) || "{}");
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (_) { return {}; }
+})();
+const state = {
+  all: [], platform: "all", category: "all", sort: "downloads", query: "",
+  trustedOnly: savedFilters.trustedOnly === true,
+  includeAi: savedFilters.includeAi !== false,
+};
+const $ = (id) => document.getElementById(id);
+const grid = $("grid");
+const loadingEl = $("loading");
+const errorEl = $("error");
+const emptyEl = $("empty");
+const resultCount = $("result-count");
+const resetBtn = $("reset");
+const trustedOnlyInput = $("trusted-only");
+const includeAiInput = $("include-ai");
+
+function isEnabled(value) { return value === true || value === 1 || value === "1" || value === "true"; }
+function saveFilterPreferences() {
+  try { localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify({ trustedOnly: state.trustedOnly, includeAi: state.includeAi })); } catch (_) {}
+}
+function syncFilterInputs() {
+  trustedOnlyInput.checked = state.trustedOnly;
+  includeAiInput.checked = state.includeAi;
+}
+syncFilterInputs();
+
+/* ---------------- boot sequence ---------------- */
+(function boot() {
+  const el = $("boot");
+  if (!el) return;
+  const dismiss = () => { el.style.animation = "boot-out 0.35s ease forwards"; };
+  window.addEventListener("keydown", dismiss, { once: true });
+  window.addEventListener("pointerdown", dismiss, { once: true });
+  setTimeout(dismiss, 2200);
+})();
+
+/* ---------------- live clock, XMB-bar style ---------------- */
+(function clock() {
+  const el = $("clock");
+  if (!el) return;
+  const tick = () => {
+    const now = new Date();
+    const hh = String(now.getHours()).padStart(2, "0");
+    const mm = String(now.getMinutes()).padStart(2, "0");
+    el.textContent = `${hh}:${mm}`;
+  };
+  tick();
+  setInterval(tick, 15000);
+})();
+
+/* ---------------- glyph helpers ---------------- */
+function glyphSvg(category) {
+  const spec = CAT_GLYPH[category];
+  if (!spec) return "";
+  const shapes = {
+    triangle: `<path class="g-triangle" d="M12 3 L21 19 L3 19 Z" stroke-width="2.6" />`,
+    square: `<rect class="g-square" x="4" y="4" width="16" height="16" rx="2" stroke-width="2.6" />`,
+    cross: `<path class="g-cross" d="M6 6 L18 18 M18 6 L6 18" stroke-width="2.6" stroke-linecap="round" />`,
+    circle: `<circle class="g-circle" cx="12" cy="12" r="8" stroke-width="2.6" />`,
+  };
+  return `<svg class="glyph-dot" viewBox="0 0 24 24" fill="none" aria-hidden="true">${shapes[spec.shape]}</svg>`;
+}
+
+function categoryOf(item) {
+  let type = parseInt(item.type, 10);
+  if (item.platform === "psp") type -= 10;
+  return CAT_MAP[type] || "Other";
+}
+
+function iconUrl(item) {
+  const iconDirectory = item.platform === "vita" ? "icons" : "icons_psp";
+  return `${iconDirectory}/${item.icon}`;
+}
+function fmtSize(bytes) {
+  const number = parseInt(bytes, 10);
+  if (!number || Number.isNaN(number)) return "—";
+  if (number >= 1024 * 1024) return `${(number / (1024 * 1024)).toFixed(1)} MB`;
+  if (number >= 1024) return `${(number / 1024).toFixed(0)} KB`;
+  return `${number} B`;
+}
+function fmtNum(value) { return (parseInt(value, 10) || 0).toLocaleString("en-US"); }
+function fmtDate(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+}
+function escapeHtml(value) {
+  return String(value || "").replace(/[&<>"']/g, (character) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[character]));
+}
+function richText(value) {
+  const escaped = escapeHtml(value);
+  return escaped.replace(/https?:\/\/[^\s<)"']+/g, (match) => `<a href="${match}" target="_blank" rel="noopener">${match}</a>`);
+}
+
+/* ---------------- data ---------------- */
+async function loadData() {
+  loadingEl.hidden = false;
+  errorEl.hidden = true;
+  emptyEl.hidden = true;
+  grid.innerHTML = "";
+  try {
+    const [vita, psp] = await Promise.all([
+      fetch(FEEDS.vita).then((response) => { if (!response.ok) throw new Error(`vita ${response.status}`); return response.json(); }),
+      fetch(FEEDS.psp).then((response) => { if (!response.ok) throw new Error(`psp ${response.status}`); return response.json(); }),
+    ]);
+    const tag = (items, platform) => items.map((item) => ({ ...item, platform, category: null }));
+    state.all = [...tag(vita, "vita"), ...tag(psp, "psp")];
+    state.all.forEach((item) => { item.category = categoryOf(item); });
+    loadingEl.hidden = true;
+    updateStats();
+    render();
+  } catch (error) {
+    loadingEl.hidden = true;
+    errorEl.hidden = false;
+    $("error-msg").textContent = error.message || "Network error";
+  }
+}
+
+function updateStats() {
+  const vita = state.all.filter((item) => item.platform === "vita").length;
+  const psp = state.all.filter((item) => item.platform === "psp").length;
+  $("stat-total").textContent = fmtNum(state.all.length);
+  $("stat-vita").textContent = fmtNum(vita);
+  $("stat-psp").textContent = fmtNum(psp);
+}
+function getFiltered() {
+  let list = state.all.slice();
+  if (state.platform !== "all") list = list.filter((item) => item.platform === state.platform);
+  if (state.category !== "all") list = list.filter((item) => item.category === state.category);
+  if (state.trustedOnly) list = list.filter((item) => isEnabled(item.trusted));
+  if (!state.includeAi) list = list.filter((item) => !isEnabled(item.ai));
+  if (state.query) {
+    const query = state.query.toLowerCase();
+    list = list.filter((item) => (item.name || "").toLowerCase().includes(query) || (item.author || "").toLowerCase().includes(query));
+  }
+  if (state.sort === "downloads") list.sort((a, b) => (parseInt(b.downloads, 10) || 0) - (parseInt(a.downloads, 10) || 0));
+  else if (state.sort === "date") list.sort((a, b) => new Date(b.date) - new Date(a.date));
+  else if (state.sort === "name") list.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+  return list;
+}
+
+/* ---------------- rendering ---------------- */
+function cardHtml(item, index) {
+  const initial = escapeHtml((item.name || "?").trim().charAt(0).toUpperCase());
+  const platformBadge = item.platform === "vita" ? '<span class="badge badge-vita">PS Vita</span>' : '<span class="badge badge-psp">PSP</span>';
+  const trusted = isEnabled(item.trusted) ? '<span class="badge badge-trusted">Trusted</span>' : "";
+  const ai = isEnabled(item.ai) ? '<span class="badge badge-ai">AI-assisted</span>' : "";
+  const direct = item.direct && item.direct !== "0" ? '<span class="badge badge-direct">Direct</span>' : "";
+  const description = escapeHtml(item.long_description || item.description || "No description available.");
+  return `<article class="card" data-plat="${item.platform}" tabindex="0" style="animation-delay:${Math.min(index, 24) * 20}ms" data-testid="card-${item.platform}-${escapeHtml(item.id)}">
+    <div class="card-top">
+      <img class="card-icon" src="${iconUrl(item)}" alt="" loading="lazy" onerror="this.classList.add('fallback');this.removeAttribute('src');this.textContent='${initial}';" />
+      <div class="card-head">
+        <p class="card-name">${escapeHtml(item.name)}</p>
+        <p class="card-author">${escapeHtml(item.author) || "Unknown"}</p>
+      </div>
+    </div>
+    <div class="badges">${platformBadge}<span class="badge badge-cat">${glyphSvg(item.category)}${escapeHtml(item.category)}</span>${trusted}${ai}${direct}</div>
+    <p class="card-description">${description}</p>
+    <div class="card-meta">
+      <span class="dl"><svg viewBox="0 0 24 24" fill="none"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>${fmtNum(item.downloads)}</span>
+      <span class="ver">${escapeHtml(item.version) || "—"}</span>
+    </div>
+  </article>`;
+}
+function render() {
+  const list = getFiltered();
+  const active = state.platform !== "all" || state.category !== "all" || state.query || state.trustedOnly || !state.includeAi;
+  resetBtn.hidden = !active;
+  resultCount.innerHTML = `<b>${fmtNum(list.length)}</b> ${list.length === 1 ? "result" : "results"}`;
+  if (!list.length) { grid.innerHTML = ""; emptyEl.hidden = false; return; }
+  emptyEl.hidden = true;
+  grid.innerHTML = list.map(cardHtml).join("");
+  Array.from(grid.children).forEach((element, index) => {
+    element.addEventListener("click", () => openModal(list[index]));
+    element.addEventListener("keydown", (event) => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); openModal(list[index]); } });
+  });
+}
+
+/* ---------------- modal ---------------- */
+const modal = $("modal");
+const modalBody = $("modal-body");
+const modalPrompts = $("modal-prompts");
+function spec(label, value, mono) { return `<div class="spec"><div class="spec-l">${label}</div><div class="spec-v ${mono ? "mono" : ""}">${value}</div></div>`; }
+
+const ICONS = {
+  cross: `<svg viewBox="0 0 24 24" fill="none"><path d="M6 6 L18 18 M18 6 L6 18" class="g-cross" stroke-width="2.6" stroke-linecap="round"/></svg>`,
+  circle: `<svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="8" class="g-circle" stroke-width="2.6"/></svg>`,
+  triangle: `<svg viewBox="0 0 24 24" fill="none"><path d="M12 3 L21 19 L3 19 Z" class="g-triangle" stroke-width="2.6"/></svg>`,
+  square: `<svg viewBox="0 0 24 24" fill="none"><rect x="4" y="4" width="16" height="16" rx="2" class="g-square" stroke-width="2.6"/></svg>`,
+};
+
+function openModal(item) {
+  const initial = escapeHtml((item.name || "?").trim().charAt(0).toUpperCase());
+  const platformBadge = item.platform === "vita" ? '<span class="badge badge-vita">PS Vita</span>' : '<span class="badge badge-psp">PSP</span>';
+  const trusted = isEnabled(item.trusted) ? '<span class="badge badge-trusted">Trusted</span>' : "";
+  const ai = isEnabled(item.ai) ? '<span class="badge badge-ai">AI-assisted</span>' : "";
+  const direct = item.direct && item.direct !== "0" ? '<span class="badge badge-direct">Direct Download</span>' : "";
+  const specs = [
+    spec("Version", escapeHtml(item.version) || "—"),
+    spec("Downloads", fmtNum(item.downloads)),
+    spec("Released", fmtDate(item.date)),
+    spec("Size", fmtSize(item.size)),
+    item.titleid ? spec("Title ID", escapeHtml(item.titleid), true) : "",
+    item.folder ? spec("Folder", escapeHtml(item.folder), true) : "",
+    item.hash ? spec("MD5", escapeHtml(item.hash), true) : "",
+    item.requirements ? spec("Requirements", escapeHtml(item.requirements)) : "",
+  ].join("");
+  const changelog = item.changelog ? `<div class="m-section-title">Changelog</div><div class="m-text m-changelog">${richText(item.changelog)}</div>` : "";
+
+  modalBody.innerHTML = `<div class="m-head">
+      <img class="m-icon" src="${iconUrl(item)}" alt="" onerror="this.classList.add('fallback','card-icon');this.removeAttribute('src');this.textContent='${initial}';" />
+      <div><h2 class="m-title">${escapeHtml(item.name)}</h2><div class="m-author">by ${escapeHtml(item.author) || "Unknown"}</div></div>
+    </div>
+    <div class="m-badges">${platformBadge}<span class="badge badge-cat">${glyphSvg(item.category)}${escapeHtml(item.category)}</span>${trusted}${ai}${direct}</div>
+    <div class="m-specs">${specs}</div>
+    ${item.long_description ? `<div class="m-section-title">About</div><div class="m-text">${richText(item.long_description)}</div>` : ""}
+    ${changelog}`;
+
+  const prompts = [];
+  if (item.url) prompts.push(`<a class="prompt prompt-primary" href="${escapeHtml(item.url)}" target="_blank" rel="noopener" data-testid="modal-download">${ICONS.cross}Download</a>`);
+  if (item.source) prompts.push(`<a class="prompt" href="${escapeHtml(item.source)}" target="_blank" rel="noopener">${ICONS.triangle}Source</a>`);
+  if (item.release_page) prompts.push(`<a class="prompt" href="${escapeHtml(item.release_page)}" target="_blank" rel="noopener">${ICONS.square}Release notes</a>`);
+  prompts.push(`<button class="prompt" id="modal-prompt-close">${ICONS.circle}Close</button>`);
+  modalPrompts.innerHTML = prompts.join("");
+  $("modal-prompt-close")?.addEventListener("click", closeModal);
+
+  modal.hidden = false;
+  document.body.style.overflow = "hidden";
+}
+function closeModal() { modal.hidden = true; document.body.style.overflow = ""; }
+
+/* ---------------- events ---------------- */
+let searchTimer;
+$("search").addEventListener("input", (event) => { clearTimeout(searchTimer); searchTimer = setTimeout(() => { state.query = event.target.value.trim(); render(); }, 160); });
+document.querySelectorAll(".xmb-tab").forEach((button) => button.addEventListener("click", () => {
+  document.querySelectorAll(".xmb-tab").forEach((item) => { item.classList.remove("active"); item.setAttribute("aria-selected", "false"); });
+  button.classList.add("active");
+  button.setAttribute("aria-selected", "true");
+  state.platform = button.dataset.platform;
+  render();
+}));
+$("category").addEventListener("change", (event) => { state.category = event.target.value; render(); });
+$("sort").addEventListener("change", (event) => { state.sort = event.target.value; render(); });
+trustedOnlyInput.addEventListener("change", (event) => { state.trustedOnly = event.target.checked; saveFilterPreferences(); render(); });
+includeAiInput.addEventListener("change", (event) => { state.includeAi = event.target.checked; saveFilterPreferences(); render(); });
+resetBtn.addEventListener("click", () => {
+  state.platform = "all"; state.category = "all"; state.query = ""; state.trustedOnly = false; state.includeAi = true;
+  $("search").value = ""; $("category").value = "all";
+  syncFilterInputs();
+  saveFilterPreferences();
+  document.querySelectorAll(".xmb-tab").forEach((button) => {
+    const isAll = button.dataset.platform === "all";
+    button.classList.toggle("active", isAll);
+    button.setAttribute("aria-selected", String(isAll));
+  });
+  render();
+});
+$("retry").addEventListener("click", loadData);
+$("modal-close").addEventListener("click", closeModal);
+document.querySelector(".modal-backdrop").addEventListener("click", closeModal);
+document.addEventListener("keydown", (event) => { if (event.key === "Escape" && !modal.hidden) closeModal(); });
+
+loadData();

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,352 @@
+/* ============================================================
+   NeoVitaDB — tokens
+   Palette drawn from the PSP XMB (deep navy + flowing wave blues)
+   and the PlayStation face buttons (triangle/circle/cross/square),
+   used here as category glyphs rather than decoration.
+   ============================================================ */
+:root {
+  --bg: #050a14;
+  --wave-1: #0c2038;
+  --wave-2: #123a63;
+  --wave-3: #1c5490;
+
+  --surface: #0d1728;
+  --surface-hi: #132038;
+  --line: #1c2c47;
+  --line-soft: #152238;
+
+  --text: #eef3fb;
+  --muted: #7d90b3;
+  --muted-dim: #526080;
+
+  --vita: #3fc8f2;
+  --vita-deep: #1a8fc4;
+  --psp: #f0a83c;
+  --psp-deep: #c97f16;
+
+  --triangle: #16c98a;
+  --circle: #ff5470;
+  --cross: #3d8bff;
+  --square: #e360e8;
+
+  --trusted: #2ee6a6;
+  --direct: #c98bff;
+
+  --radius-lg: 22px;
+  --radius-md: 14px;
+  --shadow: 0 24px 60px -24px rgba(0,0,0,0.75);
+  --font-display: "Sora", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+::selection { background: rgba(63,200,242,0.32); color: #fff; }
+button { font-family: inherit; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; }
+}
+
+/* ============================================================
+   Boot sequence — a brief power-on flash before the UI settles,
+   echoing the console startup rather than a generic loader.
+   ============================================================ */
+.boot {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: #000;
+  display: grid;
+  place-items: center;
+  animation: boot-out 0.6s ease 1.3s forwards;
+}
+.boot-sweep {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 0%, rgba(63,200,242,0.35) 48%, transparent 100%);
+  height: 3px;
+  align-self: start;
+  animation: boot-scan 1.1s cubic-bezier(.2,.7,.3,1) forwards;
+}
+.boot-mark { display: flex; flex-direction: column; align-items: center; gap: 14px; opacity: 0; animation: boot-mark-in 0.5s ease 0.55s forwards; }
+.boot-glyph { width: 46px; height: 46px; animation: boot-spin 1s cubic-bezier(.3,.7,.3,1) 0.55s; }
+.boot-label { margin: 0; font-family: var(--font-display); font-weight: 700; font-size: 13px; letter-spacing: 5px; color: var(--muted); }
+.boot-skip { position: absolute; bottom: 34px; margin: 0; font-size: 11px; letter-spacing: 2px; color: var(--muted-dim); text-transform: uppercase; opacity: 0; animation: boot-mark-in 0.4s ease 0.9s forwards; }
+
+@keyframes boot-scan { 0% { transform: translateY(0); height: 3px; } 70% { transform: translateY(100vh); height: 3px; } 100% { transform: translateY(100vh); height: 100vh; opacity: 0; } }
+@keyframes boot-mark-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+@keyframes boot-spin { from { transform: rotate(-90deg) scale(0.7); opacity: 0; } to { transform: rotate(0) scale(1); opacity: 1; } }
+@keyframes boot-out { to { opacity: 0; visibility: hidden; pointer-events: none; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .boot { animation: boot-out 0.01ms forwards; }
+}
+
+/* ============================================================
+   Wave field — slow-moving horizontal bands behind the whole
+   page, the one signature motion of the design.
+   ============================================================ */
+.wavefield { position: fixed; inset: 0; z-index: 0; overflow: hidden; pointer-events: none; }
+.wave { position: absolute; left: -25%; width: 150%; height: 640px; border-radius: 48%; filter: blur(2px); opacity: 0.55; }
+.wave-a { top: -280px; background: radial-gradient(ellipse at 50% 50%, var(--wave-3), transparent 70%); animation: drift-a 26s ease-in-out infinite; }
+.wave-b { top: -180px; background: radial-gradient(ellipse at 50% 50%, var(--wave-2), transparent 72%); opacity: 0.45; animation: drift-b 34s ease-in-out infinite; }
+.wave-c { top: -60px; background: radial-gradient(ellipse at 50% 50%, var(--wave-1), transparent 74%); opacity: 0.7; animation: drift-a 40s ease-in-out infinite reverse; }
+@keyframes drift-a { 0%,100% { transform: translateX(-3%) scaleY(1); } 50% { transform: translateX(3%) scaleY(1.08); } }
+@keyframes drift-b { 0%,100% { transform: translateX(4%) scaleY(1.05); } 50% { transform: translateX(-4%) scaleY(0.96); } }
+
+/* ============================================================
+   Face-button glyphs — reused across category tags, header
+   mark, and the boot mark.
+   ============================================================ */
+.g-triangle { fill: none; stroke: var(--triangle); stroke-width: 3.4; stroke-linejoin: round; }
+.g-circle { fill: none; stroke: var(--circle); stroke-width: 3.4; }
+.g-cross { stroke: var(--cross); }
+.g-square { fill: none; stroke: var(--square); stroke-width: 3.4; }
+
+/* ============================================================
+   XMB header bar
+   ============================================================ */
+.xmb-bar {
+  position: relative; z-index: 2;
+  max-width: 1280px; margin: 0 auto;
+  padding: 28px 28px 18px;
+  display: flex; align-items: center; justify-content: space-between; gap: 20px; flex-wrap: wrap;
+}
+.xmb-brand { display: flex; align-items: center; gap: 14px; }
+.brand-link { color: inherit; text-decoration: none; }
+.brand-glyph { width: 40px; height: 40px; flex-shrink: 0; }
+.brand-text h1 { font-family: var(--font-display); font-size: 24px; font-weight: 800; margin: 0; letter-spacing: 0.2px; }
+.brand-text h1 span { color: var(--vita); }
+.tagline { margin: 2px 0 0; color: var(--muted); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; font-family: var(--font-mono); }
+
+.xmb-tabs { display: flex; gap: 6px; background: rgba(10,17,30,0.6); border: 1px solid var(--line); border-radius: 999px; padding: 5px; backdrop-filter: blur(10px); }
+.xmb-tab {
+  display: flex; align-items: center; gap: 9px;
+  border: none; background: transparent; color: var(--muted);
+  padding: 9px 18px 9px 12px; border-radius: 999px; cursor: pointer;
+  font-family: var(--font-display); font-weight: 600; font-size: 13.5px;
+  transition: color .25s, background .25s, transform .2s;
+}
+.xmb-tab:hover { color: var(--text); }
+.xmb-tab.active { background: linear-gradient(135deg, var(--vita), var(--vita-deep)); color: #04141e; box-shadow: 0 10px 24px -12px var(--vita); transform: translateY(-1px); }
+.xmb-tab[data-platform="psp"].active { background: linear-gradient(135deg, var(--psp), var(--psp-deep)); box-shadow: 0 10px 24px -12px var(--psp); }
+.tab-icon { width: 15px; height: 15px; border-radius: 4px; display: inline-block; }
+.tab-icon-all { border-radius: 50%; background: conic-gradient(var(--vita), var(--psp), var(--triangle), var(--vita)); }
+.tab-icon-vita { transform: rotate(45deg); background: var(--vita); border-radius: 4px; }
+.xmb-tab.active .tab-icon-vita { background: #04141e; }
+.tab-icon-psp { border-radius: 50%; background: var(--psp); }
+.xmb-tab.active .tab-icon-psp { background: #04141e; }
+
+.xmb-info { display: flex; align-items: center; gap: 18px; }
+.info-clock { font-family: var(--font-mono); font-size: 13px; color: var(--muted); letter-spacing: 1px; min-width: 68px; text-align: right; }
+.info-stats { display: flex; gap: 8px; }
+.stat { background: var(--surface); border: 1px solid var(--line); border-radius: 11px; padding: 8px 14px; min-width: 66px; text-align: center; }
+.stat-num { display: block; font-family: var(--font-display); font-size: 19px; font-weight: 700; }
+.stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1.2px; color: var(--muted); }
+.developer-link { display: inline-flex; position: relative; isolation: isolate; overflow: hidden; align-items: center; gap: 8px; color: var(--vita); border: 1px solid rgba(63,200,242,0.32); border-radius: 10px; padding: 9px 12px; font-family: var(--font-display); font-size: 12px; font-weight: 600; text-decoration: none; transition: background .2s, border-color .2s, transform .2s; }
+.xmb-info .developer-link { box-shadow: 0 0 0 0 rgba(63,200,242,0.35); animation: developer-pulse 3.6s ease-in-out 1.2s infinite; }
+.developer-link::before { position: absolute; z-index: -1; top: -40%; left: -45%; width: 32%; height: 180%; content: ""; background: rgba(255,255,255,0.52); transform: skewX(-20deg); animation: developer-shine 4.8s ease-in-out 2s infinite; }
+.developer-link span { font-family: var(--font-mono); font-size: 11px; }
+.developer-link:hover { background: rgba(63,200,242,0.1); border-color: var(--vita); transform: translateY(-1px); }
+@keyframes developer-pulse { 0%, 70%, 100% { box-shadow: 0 0 0 0 rgba(63,200,242,0); } 78% { box-shadow: 0 0 0 5px rgba(63,200,242,0.12), 0 0 22px rgba(63,200,242,0.22); } 86% { box-shadow: 0 0 0 0 rgba(63,200,242,0); } }
+@keyframes developer-shine { 0%, 45% { left: -45%; opacity: 0; } 52% { opacity: 1; } 62%, 100% { left: 140%; opacity: 0; } }
+
+/* ============================================================
+   Controls
+   ============================================================ */
+.container { position: relative; z-index: 2; max-width: 1280px; margin: 0 auto; padding: 10px 28px 60px; }
+.guide-mark { color: var(--vita); font-family: var(--font-mono); font-size: 25px; font-weight: 500; letter-spacing: -1px; }
+.eyebrow { margin: 0; color: var(--vita); font-family: var(--font-mono); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; }
+.guide-code { font-family: var(--font-mono); }
+.guide-code { margin: 0; padding: 14px 16px; overflow: auto; color: #c7d3e8; background: rgba(5,10,20,0.55); border: 1px solid var(--line); border-radius: 10px; font-size: 11px; line-height: 1.65; }
+.guide-code span { color: var(--vita); }
+.guide-code em { color: var(--psp); font-style: normal; }
+.guide-code strong { color: var(--triangle); font-weight: 500; }
+.developer-page { position: relative; z-index: 2; max-width: 1060px; margin: 0 auto; padding: 42px 28px 70px; }
+.developer-hero { display: flex; align-items: center; gap: 24px; padding: 34px 38px; border: 1px solid rgba(63,200,242,0.28); border-radius: var(--radius-lg); background: linear-gradient(105deg, rgba(18,58,99,0.72), rgba(13,23,40,0.72)); box-shadow: 0 18px 40px -30px rgba(63,200,242,0.55); }
+.developer-hero .guide-mark { flex-shrink: 0; font-size: 32px; }
+.developer-hero h2 { margin: 3px 0 8px; font-family: var(--font-display); font-size: clamp(24px, 4vw, 38px); line-height: 1.1; }
+.developer-hero p:not(.eyebrow) { max-width: 680px; margin: 0; color: #c7d3e8; font-size: 15px; line-height: 1.65; }
+.developer-content { display: grid; grid-template-columns: minmax(0, 1.05fr) minmax(300px, .95fr); gap: 18px; margin-top: 18px; align-items: stretch; }
+.developer-column { display: flex; flex-direction: column; gap: 12px; height: 100%; }
+.developer-step, .developer-panel, .developer-note { border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(13,23,40,0.72); }
+.developer-step { display: grid; grid-template-columns: 42px 1fr; gap: 16px; min-height: 124px; padding: 20px; }
+.step-number { color: var(--vita); font-family: var(--font-mono); font-size: 13px; padding-top: 2px; }
+.developer-step h3 { margin: 0 0 5px; font-family: var(--font-display); font-size: 15px; }
+.developer-step p, .developer-note p { margin: 0; color: var(--muted); font-size: 13px; line-height: 1.6; }
+.developer-step code, .developer-note code { color: #c7d3e8; font-family: var(--font-mono); font-size: 11px; }
+.developer-panel { padding: 20px; }
+.developer-panel .guide-code { margin-top: 10px; }
+.developer-note { padding: 18px 20px; }
+.developer-note strong { display: block; margin-bottom: 5px; color: var(--text); font-family: var(--font-display); font-size: 13px; }
+.guide-cta { display: inline-flex; align-items: center; justify-content: space-between; gap: 14px; margin-top: auto; padding: 15px 18px; color: var(--vita); border: 1px solid rgba(63,200,242,0.32); border-radius: 11px; font-family: var(--font-display); font-size: 13px; font-weight: 600; text-decoration: none; transition: background .2s, border-color .2s, transform .2s; }
+.guide-cta:hover { background: rgba(63,200,242,0.1); border-color: var(--vita); transform: translateY(-1px); }
+.developer-reference { margin-top: 54px; padding-top: 34px; border-top: 1px solid var(--line); }
+.reference-heading { max-width: 720px; margin-bottom: 20px; }
+.reference-heading h2 { margin: 4px 0 8px; font-family: var(--font-display); font-size: 24px; }
+.reference-heading p:not(.eyebrow) { margin: 0; color: var(--muted); font-size: 14px; line-height: 1.6; }
+.reference-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 1fr; gap: 12px; align-items: stretch; }
+.reference-item { display: grid; grid-template-rows: auto 1fr auto auto; min-width: 0; padding: 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(13,23,40,0.62); }
+.reference-item h3 { margin: 0 0 7px; font-family: var(--font-display); font-size: 14px; }
+.reference-item p { margin: 0 0 13px; color: var(--muted); font-size: 12.5px; line-height: 1.6; }
+.reference-item p code { color: #c7d3e8; font-family: var(--font-mono); font-size: 10px; }
+.url-example { display: block; margin-top: 7px; padding: 9px 10px; overflow-wrap: anywhere; color: var(--vita); background: rgba(5,10,20,0.58); border: 1px solid var(--line-soft); border-radius: 8px; font-family: var(--font-mono); font-size: 10px; line-height: 1.45; }
+.controls {
+  display: flex; gap: 12px; flex-wrap: wrap; align-items: center;
+  padding: 14px; border: 1px solid var(--line); border-radius: var(--radius-md);
+  background: linear-gradient(180deg, rgba(19,32,56,0.5), rgba(13,23,40,0.5));
+  backdrop-filter: blur(14px);
+}
+.search-wrap { position: relative; flex: 1 1 280px; min-width: 220px; }
+.search-icon { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); width: 18px; height: 18px; color: var(--muted); }
+#search { width: 100%; padding: 12px 14px 12px 42px; background: #08101f; border: 1px solid var(--line); border-radius: 11px; color: var(--text); font-size: 15px; font-family: inherit; transition: border-color .2s, box-shadow .2s; }
+#search::placeholder { color: var(--muted-dim); }
+#search:focus { outline: none; border-color: var(--vita); box-shadow: 0 0 0 3px rgba(63,200,242,0.16); }
+.native-select {
+  background: #08101f; border: 1px solid var(--line); color: var(--text);
+  padding: 11px 34px 11px 14px; border-radius: 11px; font-family: inherit; font-size: 14px; cursor: pointer; appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%237d90b3' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 12px center; transition: border-color .2s;
+}
+.native-select:focus { outline: none; border-color: var(--vita); }
+:focus-visible { outline: 2px solid var(--vita); outline-offset: 2px; }
+
+.result-bar { display: flex; align-items: center; gap: 14px; margin: 18px 2px 14px; min-height: 24px; }
+.result-count { color: var(--muted); font-size: 13px; letter-spacing: 0.3px; }
+.result-count b { color: var(--text); }
+.reset-btn { background: transparent; border: 1px solid var(--line); color: var(--vita); padding: 7px 14px; border-radius: 9px; cursor: pointer; font-size: 13px; transition: background .2s, border-color .2s; }
+.reset-btn:hover { background: rgba(63,200,242,0.1); border-color: var(--vita); }
+.filter-options { display: flex; flex-wrap: wrap; gap: 8px 14px; align-items: center; flex: 1 1 100%; padding-top: 3px; border-top: 1px solid var(--line-soft); }
+.filter-option { display: inline-flex; align-items: center; gap: 8px; color: var(--muted); font-size: 12px; cursor: pointer; }
+.filter-option:hover { color: var(--text); }
+.filter-option input { width: 15px; height: 15px; margin: 0; accent-color: var(--vita); cursor: pointer; }
+
+/* ============================================================
+   Grid + LiveArea-style bubble cards
+   ============================================================ */
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(252px, 1fr)); gap: 16px; }
+
+.card {
+  position: relative; text-align: left; cursor: pointer;
+  background: linear-gradient(180deg, var(--surface), #0a1220);
+  border: 1px solid var(--line); border-radius: var(--radius-lg);
+  padding: 16px; display: flex; flex-direction: column; gap: 12px;
+  transition: transform .25s cubic-bezier(.2,.7,.3,1), border-color .25s, box-shadow .25s;
+  animation: rise .45s both;
+}
+@keyframes rise { from { opacity: 0; transform: translateY(12px) scale(0.98); } to { opacity: 1; transform: none; } }
+.card:hover, .card:focus-visible { transform: translateY(-6px) scale(1.015); border-color: var(--vita-deep); box-shadow: var(--shadow), 0 0 0 1px rgba(63,200,242,0.25); }
+.card[data-plat="psp"]:hover, .card[data-plat="psp"]:focus-visible { border-color: var(--psp-deep); box-shadow: var(--shadow), 0 0 0 1px rgba(240,168,60,0.28); }
+
+.card-top { display: flex; gap: 13px; align-items: center; }
+.card-icon { width: 56px; height: 56px; border-radius: 15px; object-fit: cover; flex-shrink: 0; background: #08101f; border: 1px solid var(--line); transition: border-color .25s, transform .25s; }
+.card:hover .card-icon { transform: scale(1.04); }
+.card-icon.fallback { display: grid; place-items: center; color: var(--muted); font-family: var(--font-display); font-size: 22px; font-weight: 700; }
+.card-head { min-width: 0; flex: 1; }
+.card-name { font-weight: 700; font-size: 15.5px; line-height: 1.25; margin: 0 0 3px; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.card-author { color: var(--muted); font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.card-description { display: -webkit-box; min-height: 3.9em; margin: 0; overflow: hidden; color: #a9b9d3; font-size: 12.5px; line-height: 1.3; -webkit-box-orient: vertical; -webkit-line-clamp: 3; }
+
+.badges { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.badge { font-size: 11px; font-weight: 600; padding: 4px 9px; border-radius: 999px; border: 1px solid transparent; letter-spacing: 0.2px; white-space: nowrap; display: inline-flex; align-items: center; gap: 5px; }
+.badge-vita { color: var(--vita); background: rgba(63,200,242,0.12); border-color: rgba(63,200,242,0.3); }
+.badge-psp { color: var(--psp); background: rgba(240,168,60,0.12); border-color: rgba(240,168,60,0.3); }
+.badge-cat { color: #c3cfe6; background: rgba(255,255,255,0.05); border-color: var(--line); }
+.badge-trusted { color: var(--trusted); background: rgba(46,230,166,0.1); border-color: rgba(46,230,166,0.3); }
+.badge-ai { color: var(--psp); background: rgba(240,168,60,0.1); border-color: rgba(240,168,60,0.3); }
+.badge-direct { color: var(--direct); background: rgba(201,139,255,0.1); border-color: rgba(201,139,255,0.3); }
+.glyph-dot { width: 9px; height: 9px; display: inline-block; flex-shrink: 0; }
+
+.card-meta { display: flex; justify-content: space-between; align-items: center; margin-top: auto; padding-top: 12px; border-top: 1px solid var(--line-soft); font-size: 12px; color: var(--muted); }
+.card-meta .dl { display: inline-flex; align-items: center; gap: 5px; }
+.card-meta .dl svg { width: 13px; height: 13px; }
+.card-meta .ver { font-family: var(--font-mono); color: #9fb0cd; font-size: 11px; max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ============================================================
+   States
+   ============================================================ */
+.state { text-align: center; padding: 70px 20px; color: var(--muted); }
+.state-title { font-family: var(--font-display); font-size: 20px; color: var(--text); margin: 0 0 6px; font-weight: 700; }
+.state-sub { margin: 0 0 18px; font-size: 14px; }
+.disc-spinner { width: 44px; height: 44px; margin: 0 auto 18px; border-radius: 50%; background: conic-gradient(from 0deg, var(--vita), transparent 60%); animation: spin 0.9s linear infinite; display: grid; place-items: center; padding: 3px; }
+.disc-spinner span { display: block; width: 100%; height: 100%; border-radius: 50%; background: var(--bg); }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ============================================================
+   Footer
+   ============================================================ */
+.site-footer { position: relative; z-index: 2; text-align: center; padding: 30px 20px 50px; color: var(--muted); font-size: 13px; }
+.site-footer a { color: var(--vita); text-decoration: none; }
+.site-footer a:hover { text-decoration: underline; }
+
+/* ============================================================
+   Modal — LiveArea detail bubble, expanded
+   ============================================================ */
+.modal { position: fixed; inset: 0; z-index: 50; display: grid; place-items: center; padding: 20px; }
+.modal[hidden] { display: none; }
+.modal-backdrop { position: absolute; inset: 0; background: rgba(3,7,14,0.78); backdrop-filter: blur(7px); animation: fade .2s; }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+.modal-card { position: relative; width: min(720px, 100%); max-height: 88vh; overflow-y: auto; background: linear-gradient(180deg, #101c31, #0a1120); border: 1px solid var(--line); border-radius: 22px; box-shadow: var(--shadow); animation: pop .3s cubic-bezier(.2,.8,.3,1); }
+@keyframes pop { from { opacity: 0; transform: translateY(18px) scale(.97); } to { opacity: 1; transform: none; } }
+.modal-close { position: absolute; top: 14px; right: 16px; z-index: 3; width: 34px; height: 34px; border-radius: 9px; border: 1px solid var(--line); background: rgba(8,16,31,0.85); color: var(--muted); font-size: 22px; line-height: 1; cursor: pointer; transition: color .2s, border-color .2s; }
+.modal-close:hover { color: var(--text); border-color: var(--vita); }
+.modal-body { padding: 26px 26px 6px; }
+.m-head { display: flex; gap: 16px; align-items: center; margin-bottom: 18px; padding-right: 40px; }
+.m-icon { width: 76px; height: 76px; border-radius: 18px; object-fit: cover; background: #08101f; border: 1px solid var(--line); flex-shrink: 0; }
+.m-title { font-family: var(--font-display); font-size: 22px; margin: 0 0 4px; line-height: 1.2; font-weight: 700; }
+.m-author { color: var(--muted); font-size: 14px; }
+.m-badges { margin: 14px 0 20px; display: flex; flex-wrap: wrap; gap: 7px; }
+.m-specs { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; margin-bottom: 20px; }
+.spec { background: rgba(8,16,31,0.6); border: 1px solid var(--line-soft); border-radius: 11px; padding: 10px 12px; }
+.spec-l { font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; color: var(--muted); margin-bottom: 3px; }
+.spec-v { font-size: 14px; color: var(--text); font-weight: 600; word-break: break-word; }
+.spec-v.mono { font-family: var(--font-mono); font-size: 12px; font-weight: 500; }
+.m-section-title { font-family: var(--font-display); font-size: 13px; text-transform: uppercase; letter-spacing: 1.2px; color: var(--vita); margin: 20px 0 8px; font-weight: 700; }
+.m-text { color: #c7d3e8; font-size: 14px; line-height: 1.6; white-space: pre-wrap; word-break: break-word; }
+.m-text a { color: var(--vita); }
+.m-changelog { max-height: 220px; overflow-y: auto; background: rgba(8,16,31,0.5); border: 1px solid var(--line-soft); border-radius: 11px; padding: 14px; }
+
+/* Button-prompt bar, echoing the on-screen glyph prompts of PS UIs */
+.modal-prompts { display: flex; flex-wrap: wrap; gap: 18px; padding: 16px 26px; border-top: 1px solid var(--line-soft); background: rgba(5,10,20,0.5); }
+.prompt { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; color: var(--text); font-size: 13.5px; font-weight: 600; cursor: pointer; border: none; background: none; padding: 0; transition: opacity .2s, transform .2s; }
+.prompt:hover { opacity: 0.8; transform: translateY(-1px); }
+.prompt svg { width: 18px; height: 18px; }
+.prompt.prompt-primary { color: var(--cross); }
+
+/* ============================================================
+   Responsive
+   ============================================================ */
+@media (max-width: 760px) {
+  .xmb-bar { padding: 22px 18px 6px; }
+  .xmb-info { width: 100%; justify-content: space-between; }
+  .container { padding: 10px 18px 50px; }
+  .controls { padding: 12px; }
+  .developer-page { padding: 24px 18px 50px; }
+  .developer-hero { align-items: flex-start; gap: 14px; padding: 24px; }
+  .developer-hero .guide-mark { display: none; }
+  .developer-content { grid-template-columns: 1fr; }
+  .developer-column { height: auto; }
+  .reference-grid { grid-template-columns: 1fr; grid-auto-rows: auto; }
+  .native-select { flex: 1; }
+  .grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 12px; }
+  .modal-body { padding: 20px 18px 4px; }
+  .modal-prompts { padding: 14px 18px; }
+  .m-head { flex-direction: column; text-align: center; padding-right: 0; }
+}
+@media (max-width: 460px) {
+  .info-clock { display: none; }
+  .brand-text .tagline { display: none; }
+  .xmb-info { flex-wrap: wrap; gap: 10px; }
+  .xmb-info .developer-link { width: 100%; justify-content: center; }
+}


### PR DESCRIPTION
I added a default GitHub Pages website so the repository does not open with a 404 page anymore.

It lets people browse the Vita and PSP homebrew catalog, search and filter entries, and open details. I also added a small developer page explaining how to add homebrew and use the catalog feeds and icons.